### PR TITLE
Enable peer-aware P2P chat with resilient client handling

### DIFF
--- a/src/client/ChatPeer.java
+++ b/src/client/ChatPeer.java
@@ -5,8 +5,8 @@ import java.net.*;
 import java.util.Scanner;
 
 public class ChatPeer {
-    public static void startChat(String user, String target) {
-        try (Socket peer = new Socket("localhost", 6000);
+    public static void startChat(String user, String target, String host, int port) {
+        try (Socket peer = new Socket(host, port);
              PrintWriter pw = new PrintWriter(peer.getOutputStream(), true)) {
             Scanner sc = new Scanner(System.in);
             System.out.println("Chat với " + target + " (gõ /exit để thoát)");

--- a/src/client/ChatWindow.java
+++ b/src/client/ChatWindow.java
@@ -2,6 +2,8 @@ package client;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.io.*;
 import java.net.*;
 import java.util.List;
@@ -52,12 +54,43 @@ public class ChatWindow extends JFrame {
                 txtMessage.setText("");
             }
         });
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                closeConnection();
+            }
+
+            @Override
+            public void windowClosing(WindowEvent e) {
+                closeConnection();
+            }
+        });
     }
 
     private void loadHistory() {
         List<String> history = messageDAO.getConversation(user, target);
         for (String line : history) {
             chatArea.append(line + "\n");
+        }
+    }
+
+    public void appendIncomingMessage(String sender, String message) {
+        chatArea.append(sender + ": " + message + "\n");
+        messageDAO.saveMessage(sender, user, message);
+    }
+
+    private void closeConnection() {
+        if (pw != null) {
+            pw.close();
+            pw = null;
+        }
+        if (socket != null && !socket.isClosed()) {
+            try {
+                socket.close();
+            } catch (IOException ignored) {
+            }
+            socket = null;
         }
     }
 }

--- a/src/client/ClientApp.java
+++ b/src/client/ClientApp.java
@@ -1,46 +1,69 @@
 package client;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ClientApp {
-    private static List<String> onlineUsers = new ArrayList<>();
+    private static volatile List<String> onlineUsers = new ArrayList<>();
+    private static final Map<String, PeerInfo> peerInfoMap = new ConcurrentHashMap<>();
 
-    public static void main(String[] args) throws IOException {
-        Socket server = new Socket("localhost", 5000);
-        BufferedReader in = new BufferedReader(new InputStreamReader(server.getInputStream()));
-        PrintWriter out = new PrintWriter(server.getOutputStream(), true);
-
+    public static void main(String[] args) {
         Scanner sc = new Scanner(System.in);
-        System.out.print("Username: ");
-        String user = sc.nextLine();
-        System.out.print("Password: ");
-        String pass = sc.nextLine();
+        PeerServer peerServer = null;
+        Socket server = null;
+        try {
+            int peerPort = 6000 + (int) (Math.random() * 1000);
+            peerServer = new PeerServer(peerPort, (sender, message, host) ->
+                    System.out.println("\n[Tin nhắn] " + sender + ": " + message));
+            new Thread(peerServer, "PeerServer-CLI").start();
+            System.out.println("PeerServer lắng nghe ở port " + peerPort);
 
-        out.println("LOGIN:" + user + ":" + pass);
-        String response = in.readLine();
-        if (!"LOGIN_OK".equals(response)) {
-            System.out.println("Sai tài khoản hoặc mật khẩu!");
-            return;
-        }
+            server = new Socket("localhost", 5000);
+            BufferedReader in = new BufferedReader(new InputStreamReader(server.getInputStream()));
+            PrintWriter out = new PrintWriter(server.getOutputStream(), true);
 
-        // Thread lắng nghe danh sách online
-        new Thread(() -> {
-            try {
-                String line;
-                while ((line = in.readLine()) != null) {
-                    if (line.startsWith("ONLINE_LIST:")) {
-                        onlineUsers = Arrays.asList(line.substring(12).split(","));
-                        System.out.println("\n[Danh sách online] " + onlineUsers);
-                    }
-                }
-            } catch (IOException e) {
-                System.out.println("Mất kết nối server");
+            System.out.print("Username: ");
+            String user = sc.nextLine();
+            System.out.print("Password: ");
+            String pass = sc.nextLine();
+
+            out.println("LOGIN:" + user + ":" + pass + ":" + peerPort);
+            String response = in.readLine();
+            if (!"LOGIN_OK".equals(response)) {
+                System.out.println("Sai tài khoản hoặc mật khẩu!");
+                return;
             }
-        }).start();
 
-        // Menu chat
+            BufferedReader reader = in;
+            Thread listener = new Thread(() -> listenForUpdates(reader, user));
+            listener.setDaemon(true);
+            listener.start();
+
+            menuLoop(sc, out, server, user);
+        } catch (IOException e) {
+            System.out.println("Không thể kết nối server: " + e.getMessage());
+        } finally {
+            if (peerServer != null) {
+                peerServer.stop();
+            }
+            if (server != null && !server.isClosed()) {
+                try {
+                    server.close();
+                } catch (IOException ignored) {
+                }
+            }
+        }
+    }
+
+    private static void menuLoop(Scanner sc, PrintWriter out, Socket server, String user) {
         while (true) {
             System.out.println("\n1. Xem danh sách online");
             System.out.println("2. Chat với ai đó");
@@ -49,18 +72,83 @@ public class ClientApp {
 
             switch (choice) {
                 case "1":
-                    System.out.println("Online: " + onlineUsers);
+                    System.out.println("Online: " + new ArrayList<>(onlineUsers));
                     break;
                 case "2":
                     System.out.print("Nhập tên người muốn chat: ");
                     String target = sc.nextLine();
-                    ChatPeer.startChat(user, target);
+                    PeerInfo info = peerInfoMap.get(target);
+                    if (info == null) {
+                        System.out.println("Người dùng không khả dụng.");
+                        break;
+                    }
+                    ChatPeer.startChat(user, target, info.getHost(), info.getPort());
                     break;
                 case "3":
-                    out.println("LOGOUT:" + user);
-                    server.close();
+                    if (out != null) {
+                        out.println("LOGOUT:" + user);
+                    }
+                    if (server != null && !server.isClosed()) {
+                        try {
+                            server.close();
+                        } catch (IOException ignored) {
+                        }
+                    }
                     return;
+                default:
+                    System.out.println("Lựa chọn không hợp lệ.");
             }
         }
+    }
+
+    private static void listenForUpdates(BufferedReader in, String currentUser) {
+        try {
+            String line;
+            while ((line = in.readLine()) != null) {
+                if (line.startsWith("ONLINE_LIST:")) {
+                    updatePeerInfo(line.substring(12), currentUser);
+                }
+            }
+        } catch (IOException e) {
+            System.out.println("Mất kết nối server");
+        }
+    }
+
+    private static void updatePeerInfo(String payload, String currentUser) {
+        Map<String, PeerInfo> updated = new ConcurrentHashMap<>();
+        if (payload != null && !payload.isEmpty()) {
+            String[] entries = payload.split(";");
+            for (String entry : entries) {
+                if (entry == null || entry.isEmpty()) {
+                    continue;
+                }
+                String[] parts = entry.split("\\|");
+                if (parts.length < 3) {
+                    continue;
+                }
+                String username = parts[0].trim();
+                String host = parts[1].trim();
+                int port;
+                try {
+                    port = Integer.parseInt(parts[2].trim());
+                } catch (NumberFormatException e) {
+                    continue;
+                }
+                if (!username.isEmpty()) {
+                    updated.put(username, new PeerInfo(username, host, port));
+                }
+            }
+        }
+
+        peerInfoMap.clear();
+        peerInfoMap.putAll(updated);
+        List<String> display = new ArrayList<>();
+        for (String name : updated.keySet()) {
+            if (!name.equals(currentUser)) {
+                display.add(name);
+            }
+        }
+        onlineUsers = display;
+        System.out.println("\n[Danh sách online] " + display);
     }
 }

--- a/src/client/ClientGUI.java
+++ b/src/client/ClientGUI.java
@@ -6,6 +6,7 @@ import java.awt.event.*;
 import java.io.*;
 import java.net.*;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ClientGUI extends JFrame {
     private JTextField txtUsername;
@@ -17,6 +18,11 @@ public class ClientGUI extends JFrame {
     private BufferedReader in;
     private PrintWriter out;
     private String currentUser;
+    private PeerServer peerServer;
+    private int peerPort;
+    private final Map<String, PeerInfo> peerInfoMap = new ConcurrentHashMap<>();
+    private final Map<String, ChatWindow> chatWindows = new ConcurrentHashMap<>();
+    private volatile boolean intentionalDisconnect = false;
 
     public ClientGUI() {
         setTitle("Client - P2P Chat");
@@ -61,9 +67,16 @@ public class ClientGUI extends JFrame {
     }
 
     private void login() {
-        int peerPort = 6000 + (int)(Math.random() * 1000);
-    new Thread(new PeerServer(peerPort)).start();
-    System.out.println("PeerServer lắng nghe ở port " + peerPort);
+        if (currentUser != null) {
+            return;
+        }
+
+        stopPeerServer();
+        peerPort = 6000 + (int) (Math.random() * 1000);
+        peerServer = new PeerServer(peerPort, this::handleIncomingMessage);
+        new Thread(peerServer, "PeerServer-" + peerPort).start();
+        System.out.println("PeerServer lắng nghe ở port " + peerPort);
+
         try {
             serverSocket = new Socket("localhost", 5000);
             in = new BufferedReader(new InputStreamReader(serverSocket.getInputStream()));
@@ -71,7 +84,8 @@ public class ClientGUI extends JFrame {
 
             String username = txtUsername.getText().trim();
             String password = new String(txtPassword.getPassword());
-            out.println("LOGIN:" + username + ":" + password);
+            intentionalDisconnect = false;
+            out.println("LOGIN:" + username + ":" + password + ":" + peerPort);
 
             String response = in.readLine();
             if ("LOGIN_OK".equals(response)) {
@@ -80,58 +94,198 @@ public class ClientGUI extends JFrame {
                 btnLogin.setEnabled(false);
                 btnLogout.setEnabled(true);
                 btnChat.setEnabled(true);
-                new Thread(() -> listenServer()).start();
+                new Thread(this::listenServer, "ServerListener").start();
             } else {
                 JOptionPane.showMessageDialog(this, "Sai username/password!");
+                intentionalDisconnect = true;
+                stopPeerServer();
+                closeServerConnection();
             }
         } catch (IOException ex) {
+            stopPeerServer();
+            closeServerConnection();
             JOptionPane.showMessageDialog(this, "Không thể kết nối server!");
         }
     }
 
     private void logout() {
-        if (out != null) {
+        if (currentUser == null && out == null) {
+            return;
+        }
+
+        intentionalDisconnect = true;
+        if (out != null && currentUser != null) {
             out.println("LOGOUT:" + currentUser);
         }
-        try {
-            if (serverSocket != null) serverSocket.close();
-        } catch (IOException ignored) {}
+
+        closeServerConnection();
+        stopPeerServer();
+        peerInfoMap.clear();
+
+        for (ChatWindow window : new ArrayList<>(chatWindows.values())) {
+            window.dispose();
+        }
+        chatWindows.clear();
+
         onlineModel.clear();
         btnLogin.setEnabled(true);
         btnLogout.setEnabled(false);
         btnChat.setEnabled(false);
+        currentUser = null;
+        intentionalDisconnect = false;
     }
 
     private void listenServer() {
         try {
             String line;
-            while ((line = in.readLine()) != null) {
+            while (true) {
+                BufferedReader reader = in;
+                if (reader == null) {
+                    break;
+                }
+                line = reader.readLine();
+                if (line == null) {
+                    break;
+                }
                 if (line.startsWith("ONLINE_LIST:")) {
-                    String[] users = line.substring(12).split(",");
-                    SwingUtilities.invokeLater(() -> {
-                        onlineModel.clear();
-                        for (String u : users) {
-                            if (!u.isEmpty() && !u.equals(currentUser)) {
-                                onlineModel.addElement(u);
-                            }
-                        }
-                    });
+                    processOnlineList(line.substring(12));
                 }
             }
         } catch (IOException e) {
-            JOptionPane.showMessageDialog(this, "Mất kết nối server.");
+            handleServerDisconnect();
+            return;
+        }
+
+        handleServerDisconnect();
+    }
+
+    private void processOnlineList(String payload) {
+        Map<String, PeerInfo> updated = new HashMap<>();
+        if (payload != null && !payload.isEmpty()) {
+            String[] entries = payload.split(";");
+            for (String entry : entries) {
+                if (entry == null || entry.isEmpty()) {
+                    continue;
+                }
+                String[] parts = entry.split("\\|");
+                if (parts.length < 3) {
+                    continue;
+                }
+                String username = parts[0].trim();
+                String host = parts[1].trim();
+                int port;
+                try {
+                    port = Integer.parseInt(parts[2].trim());
+                } catch (NumberFormatException ex) {
+                    continue;
+                }
+                if (!username.isEmpty()) {
+                    updated.put(username, new PeerInfo(username, host, port));
+                }
+            }
+        }
+
+        peerInfoMap.clear();
+        peerInfoMap.putAll(updated);
+
+        SwingUtilities.invokeLater(() -> {
+            onlineModel.clear();
+            for (String user : updated.keySet()) {
+                if (!user.equals(currentUser)) {
+                    onlineModel.addElement(user);
+                }
+            }
+        });
+    }
+
+    private void handleIncomingMessage(String sender, String message, String hostAddress) {
+        if (sender == null || sender.isEmpty()) {
+            sender = hostAddress != null ? hostAddress : "Unknown";
+        }
+        final String fromUser = sender;
+        final String content = message;
+
+        SwingUtilities.invokeLater(() -> {
+            ChatWindow window = chatWindows.get(fromUser);
+            if (window == null) {
+                PeerInfo info = peerInfoMap.get(fromUser);
+                if (info == null) {
+                    JOptionPane.showMessageDialog(this, fromUser + ": " + content);
+                    return;
+                }
+                window = openChatWindow(info);
+            }
+            if (window != null) {
+                window.appendIncomingMessage(fromUser, content);
+            }
+        });
+    }
+
+    private ChatWindow openChatWindow(PeerInfo info) {
+        if (info == null) {
+            return null;
+        }
+
+        ChatWindow existing = chatWindows.get(info.getUsername());
+        if (existing != null) {
+            existing.toFront();
+            existing.requestFocus();
+            return existing;
+        }
+
+        ChatWindow window = new ChatWindow(currentUser, info.getUsername(), info.getHost(), info.getPort());
+        chatWindows.put(info.getUsername(), window);
+        window.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                chatWindows.remove(info.getUsername());
+            }
+        });
+        window.setVisible(true);
+        return window;
+    }
+
+    private void handleServerDisconnect() {
+        closeServerConnection();
+        if (!intentionalDisconnect) {
+            SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(this, "Mất kết nối server."));
+        }
+        intentionalDisconnect = false;
+    }
+
+    private void stopPeerServer() {
+        if (peerServer != null) {
+            peerServer.stop();
+            peerServer = null;
         }
     }
 
-    private void startChat() {
-    String selected = listOnline.getSelectedValue();
-    if (selected != null) {
-        // Tạm thời test, sau này phải lấy port của peer từ server
-        String peerIP = "localhost";
-        int peerPort = 6000;
-        new ChatWindow(currentUser, selected, peerIP, peerPort).setVisible(true);
+    private void closeServerConnection() {
+        if (serverSocket != null && !serverSocket.isClosed()) {
+            try {
+                serverSocket.close();
+            } catch (IOException ignored) {
+            }
+        }
+        serverSocket = null;
+        in = null;
+        out = null;
     }
-}
+
+    private void startChat() {
+        String selected = listOnline.getSelectedValue();
+        if (selected == null) {
+            return;
+        }
+
+        PeerInfo info = peerInfoMap.get(selected);
+        if (info == null) {
+            JOptionPane.showMessageDialog(this, "Không tìm thấy thông tin peer của " + selected);
+            return;
+        }
+
+        openChatWindow(info);
+    }
 
 
     public static void main(String[] args) {

--- a/src/client/PeerInfo.java
+++ b/src/client/PeerInfo.java
@@ -1,0 +1,25 @@
+package client;
+
+public class PeerInfo {
+    private final String username;
+    private final String host;
+    private final int port;
+
+    public PeerInfo(String username, String host, int port) {
+        this.username = username;
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+}

--- a/src/client/PeerServer.java
+++ b/src/client/PeerServer.java
@@ -1,24 +1,57 @@
 package client;
 
-import java.io.*;
-import java.net.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
 
 public class PeerServer implements Runnable {
-    private int port;
+    private final int port;
+    private final MessageHandler handler;
+    private volatile boolean running = true;
+    private ServerSocket serverSocket;
 
-    public PeerServer(int port) {
+    public PeerServer(int port, MessageHandler handler) {
         this.port = port;
+        this.handler = handler;
     }
 
     @Override
     public void run() {
-        try (ServerSocket server = new ServerSocket(port)) {
-            while (true) {
-                Socket socket = server.accept();
-                new Thread(() -> handleClient(socket)).start();
+        try {
+            serverSocket = new ServerSocket(port);
+            while (running) {
+                try {
+                    Socket socket = serverSocket.accept();
+                    new Thread(() -> handleClient(socket)).start();
+                } catch (SocketException e) {
+                    if (running) {
+                        System.out.println("PeerServer error: " + e.getMessage());
+                    }
+                }
             }
         } catch (IOException e) {
-            System.out.println("PeerServer stopped: " + e.getMessage());
+            if (running) {
+                System.out.println("PeerServer stopped: " + e.getMessage());
+            }
+        } finally {
+            closeServerSocket();
+        }
+    }
+
+    public void stop() {
+        running = false;
+        closeServerSocket();
+    }
+
+    private void closeServerSocket() {
+        if (serverSocket != null && !serverSocket.isClosed()) {
+            try {
+                serverSocket.close();
+            } catch (IOException ignored) {
+            }
         }
     }
 
@@ -26,9 +59,23 @@ public class PeerServer implements Runnable {
         try (BufferedReader br = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
             String line;
             while ((line = br.readLine()) != null) {
-                System.out.println("[Tin nhắn mới] " + line);
-                // Bạn có thể cập nhật UI chat nếu đang mở ChatWindow tương ứng
+                if (handler != null) {
+                    int idx = line.indexOf(':');
+                    String sender = idx >= 0 ? line.substring(0, idx).trim() : "";
+                    String message = idx >= 0 ? line.substring(idx + 1).trim() : line;
+                    handler.onIncomingMessage(sender, message, socket.getInetAddress().getHostAddress());
+                }
             }
-        } catch (IOException ignored) {}
+        } catch (IOException ignored) {
+        } finally {
+            try {
+                socket.close();
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    public interface MessageHandler {
+        void onIncomingMessage(String sender, String message, String hostAddress);
     }
 }

--- a/src/server/LibraryServer.java
+++ b/src/server/LibraryServer.java
@@ -1,12 +1,18 @@
 package server;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public class LibraryServer {
     private static final int PORT = 5000;
-    private static Map<String, ClientHandler> onlineClients = new HashMap<>();
+    private static final Map<String, ClientHandler> onlineClients = new ConcurrentHashMap<>();
 
     public static void main(String[] args) throws IOException {
         try (ServerSocket serverSocket = new ServerSocket(PORT)) {
@@ -19,55 +25,119 @@ public class LibraryServer {
     }
 
     static class ClientHandler implements Runnable {
-        private Socket socket;
+        private final Socket socket;
         private String username;
+        private int peerPort;
+        private PrintWriter out;
 
         ClientHandler(Socket socket) {
             this.socket = socket;
         }
 
         public void run() {
-            try (BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-                 PrintWriter out = new PrintWriter(socket.getOutputStream(), true)) {
+            try {
+                BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+                out = new PrintWriter(socket.getOutputStream(), true);
 
                 while (true) {
                     String line = in.readLine();
                     if (line == null) break;
 
-                    String[] parts = line.split(":", 3);
+                    String[] parts = line.split(":", 4);
                     switch (parts[0]) {
                         case "LOGIN":
-                            username = parts[1];
-                            String password = parts[2];
-                            UserDAO dao = new UserDAO();
-                            if (dao.checkLogin(username, password)) {
-                                onlineClients.put(username, this);
-                                out.println("LOGIN_OK");
-                                broadcastOnlineList();
-                            } else {
-                                out.println("LOGIN_FAIL");
-                            }
+                            handleLogin(parts);
                             break;
                         case "LOGOUT":
-                            onlineClients.remove(username);
-                            broadcastOnlineList();
-                            socket.close();
+                            out.println("LOGOUT_OK");
                             return;
+                        default:
+                            out.println("UNKNOWN_COMMAND");
                     }
                 }
             } catch (IOException e) {
-                onlineClients.remove(username);
+                // client disconnected unexpectedly
+            } finally {
+                cleanup();
             }
+        }
+
+        private void handleLogin(String[] parts) {
+            if (parts.length < 4) {
+                out.println("LOGIN_FAIL");
+                return;
+            }
+
+            String attemptedUser = parts[1];
+            String password = parts[2];
+            int peerPortCandidate;
+            try {
+                peerPortCandidate = Integer.parseInt(parts[3]);
+            } catch (NumberFormatException e) {
+                out.println("LOGIN_FAIL");
+                return;
+            }
+            if (peerPortCandidate <= 0 || peerPortCandidate > 65535) {
+                out.println("LOGIN_FAIL");
+                return;
+            }
+
+            UserDAO dao = new UserDAO();
+            if (dao.checkLogin(attemptedUser, password)) {
+                username = attemptedUser;
+                peerPort = peerPortCandidate;
+
+                ClientHandler existing = onlineClients.put(username, this);
+                if (existing != null && existing != this) {
+                    existing.closeSilently();
+                }
+
+                out.println("LOGIN_OK");
+                broadcastOnlineList();
+            } else {
+                out.println("LOGIN_FAIL");
+            }
+        }
+
+        private void cleanup() {
+            if (username != null) {
+                if (onlineClients.remove(username, this)) {
+                    broadcastOnlineList();
+                }
+            }
+            closeSilently();
+        }
+
+        private void closeSilently() {
+            try {
+                socket.close();
+            } catch (IOException ignored) {
+            }
+        }
+
+        private void sendMessage(String message) {
+            if (out != null) {
+                out.println(message);
+            }
+        }
+
+        private String getPeerInfo() {
+            if (username == null) {
+                return "";
+            }
+            String host = socket.getInetAddress().getHostAddress();
+            return username + "|" + host + "|" + peerPort;
         }
     }
 
     private static void broadcastOnlineList() {
-        String list = String.join(",", onlineClients.keySet());
-        for (ClientHandler c : onlineClients.values()) {
-            try {
-                new PrintWriter(c.socket.getOutputStream(), true)
-                    .println("ONLINE_LIST:" + list);
-            } catch (IOException ignored) {}
+        String list = onlineClients.values().stream()
+                .map(ClientHandler::getPeerInfo)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining(";"));
+
+        for (ClientHandler client : onlineClients.values()) {
+            client.sendMessage("ONLINE_LIST:" + list);
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend the server to track each client's peer address/port and broadcast that information with the online list
- refactor GUI and CLI clients to register their peer servers, maintain peer metadata, and open chat windows directly against peers
- add utilities for handling incoming messages, managing chat windows, and closing sockets cleanly on logout or window close

## Testing
- `javac -d out @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68c91a303f90832794b93e98b2a68a6a